### PR TITLE
Fix version files' URL properties

### DIFF
--- a/GameData/SRCS/SRCS.version
+++ b/GameData/SRCS/SRCS.version
@@ -1,6 +1,6 @@
 {
   "NAME": "SRCS",
-  "URL": "https://github.com/kurgut/SRCS-Stageable-RCS",
+  "URL": "https://raw.githubusercontent.com/kurgut/SRCS-Stageable-RCS/main/GameData/SRCS/SRCS.version",
   "DOWNLOAD": "https://github.com/kurgut/SRCS-Stageable-RCS/releases",
   "GITHUB": {
     "USERNAME": "kurgut",

--- a/SRCS.version
+++ b/SRCS.version
@@ -1,6 +1,6 @@
 {
   "NAME": "SRCS",
-  "URL": "https://github.com/kurgut/SRCS-Stageable-RCS",
+  "URL": "https://raw.githubusercontent.com/kurgut/SRCS-Stageable-RCS/main/GameData/SRCS/SRCS.version",
   "DOWNLOAD": "https://github.com/kurgut/SRCS-Stageable-RCS/releases",
   "GITHUB": {
     "USERNAME": "kurgut",


### PR DESCRIPTION
H @kurgut 

The `URL` property of a version file is supposed to point to an online copy of the version file itself that can be updated on the fly to contain the latest version and compatibility info. Currently it points to this repository, which isn't right. This PR fixes it.

Noticed while reviewing KSP-CKAN/NetKAN#9686.

![image](https://github.com/kurgut/SRCS-Stageable-RCS/assets/1559108/4a36a69e-502d-4298-81b9-7572f68675f7)

- <https://github.com/KSP-CKAN/NetKAN/actions/runs/5028859758/jobs/9019963430?pr=9686>
